### PR TITLE
fix: Adjust permissions for nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,6 +33,7 @@ jobs:
     permissions:
       security-events: write
       contents: read
+      packages: read # required for pulling images from GHCR
     uses: open-crypto-broker/.github/.github/workflows/security-scan.yaml@main # nolint # zizmor: ignore[unpinned-uses]
     with:
       scan_image: ${{ inputs.scan_image || true }}


### PR DESCRIPTION
## Description
Reapply "packages: read" permission to allow pulling images from GHCR.

## Type of change
- [x] Bug fix
- [ ] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
