### PR TITLE
fix: Adjust permissions for docker release, add GitHub release stage

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,36 @@ concurrency:
 permissions: {}
 
 jobs:
+  ################################################
+  # GitHub release with changelog details
+  ################################################
+  github-release:
+    name: Create GitHub Release
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Extract release notes from CHANGELOG.md
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          VERSION="${TAG#v}"
+          awk -v ver="$VERSION" '
+            /^## \[/ { if (found) exit; if (index($0, "[" ver "]")) found=1; next }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: gh release create "$TAG" --verify-tag -F release-notes.md
 
   ################################################
   # Metadata (reusable workflow)
@@ -58,15 +88,16 @@ jobs:
       tag: ${{ needs.metadata.outputs.tag }}
 
   ################################################
-  # Docker + Security (reusable workflow)
+  # Build Docker + Security scan (reusable workflow)
   ################################################
-  release:
+  build-docker:
     needs: metadata
     permissions:
-      contents: write
+      contents: read
       packages: write
-      security-events: write
       id-token: write
+      attestations: write
+      artifact-metadata: write
 
     uses: open-crypto-broker/.github/.github/workflows/release-docker-security.yaml@main # nolint # zizmor: ignore[unpinned-uses]
     with:


### PR DESCRIPTION
## Description
Rework the required permissions for the docker release workflow.
Add a GitHub release stage for automatic release creation.

## Type of change
- [x] Bug fix
- [x] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
