### PR TITLE
Fix: Restrict unix socket permission during creation

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -97,12 +97,15 @@ func main() {
 
 	rpcLogger.Debug("Directory for socket file exists", slog.String("path", baseDir))
 	rpcLogger.Debug("Attempting to listen on socket", slog.String("address", defaultSocketPath))
+
+	// Restrict unix socket permissions to owner during creation.
+	mask := syscall.Umask(0177)
 	listener, err := net.Listen("unix", defaultSocketPath)
 	if err != nil {
 		rpcLogger.Error("Failed to listen on socket", slog.String("address", defaultSocketPath), slog.String("error", err.Error()))
-
 		panic(err)
 	}
+	syscall.Umask(mask)
 
 	if err = os.Chmod(defaultSocketPath, 0600); err != nil {
 		rpcLogger.Error("Failed to set socket file permissions", slog.String("path", defaultSocketPath), slog.String("error", err.Error()))


### PR DESCRIPTION
## Description
Fix unix socket permission during creation.

#265

## Type of change
- [x] Bug fix
- [ ] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

