### PR TITLE
feat: set max concurrent streams in gprc server to 1024

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,6 @@ OTEL_EXPORTER_OTLP_HEADERS_AUTHORIZATION="API-Token"
 
 # PProf address
 PPROF_ADDR=127.0.0.1:6060
+
+# Set max number of concurrent streams for grpc server
+GRPC_MAX_CONCURRENT_STREAMS=1024

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -158,6 +159,7 @@ func main() {
 		),
 		grpc.MaxRecvMsgSize(api.MaxGrpcRecvMsgSize),
 		grpc.MaxSendMsgSize(api.MaxGrpcSendMsgSize),
+		grpc.MaxConcurrentStreams(getMaxConcurrentStreams()),
 	)
 
 	// Register crypto broker service
@@ -229,4 +231,18 @@ func main() {
 
 		panic(err)
 	}
+}
+
+func getMaxConcurrentStreams() uint32 {
+	maxConcurrentStreams := uint32(1024)
+	val := os.Getenv(env.GRPC_MAX_CONCURRENT_STREAMS)
+
+	if val != "" {
+		custom, err := strconv.ParseUint(val, 10, 32)
+		if err == nil {
+			maxConcurrentStreams = uint32(custom)
+		}
+	}
+
+	return maxConcurrentStreams
 }

--- a/docs/envs.md
+++ b/docs/envs.md
@@ -1,6 +1,7 @@
 | Variable | Required | Default | Description | Valid Values |
 | -------- | -------- | ------- | ----------- | ------------ |
 | `CRYPTO_BROKER_APP_ENV` | No | prod | Specifies the server runtime environment | `prod`, `dev` |
+| `CRYPTO_BROKER_GRPC_MAX_CONCURRENT_STREAMS` | No | 1024 | Specifies how many concurrent connections server can accept | uint32 |
 | `CRYPTO_BROKER_PROFILES_DIR` | Yes | - | Full OS path to directory containing profile files in YAML format | Any valid directory path |
 | `CRYPTO_BROKER_LOG_LEVEL` | No | `info` | Log level for the server | `debug`, `info`, `warn`, `error` |
 | `CRYPTO_BROKER_LOG_FORMAT` | No | `json` | Log output format | `json`, `text` |

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -86,4 +86,7 @@ const (
 	// PPROF_ADDR is optional TCP listen address for net/http/pprof (CPU, heap, etc.).
 	// When empty, the pprof HTTP endpoint is disabled. Use a loopback address (e.g. "127.0.0.1:6060") for local profiling and PGO.
 	PPROF_ADDR = "CRYPTO_BROKER_PPROF_ADDR"
+
+	// GRPC_MAX_CONCURRENT_STREAMS sets max number of concurrent streams for grpc server.
+	GRPC_MAX_CONCURRENT_STREAMS = "CRYPTO_BROKER_GRPC_MAX_CONCURRENT_STREAMS"
 )


### PR DESCRIPTION
## Description
Set max number of concurrent streams in grpc server (#272)

## Type of change
- [ ] Bug fix
- [] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [x ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [ ] Supplied as many details as possible on this change
- [ ] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
