### PR TITLE
Use SAP correlation_id field

### DIFF
--- a/docs/otel.md
+++ b/docs/otel.md
@@ -50,7 +50,7 @@ The server generates the following trace spans:
 * **Attributes Included**(full list in [attr.go](./internal/otel/attr.go)]):
     * `rpc.method`: The gRPC method name
     * `crypto.profile`: The cryptographic profile used
-    * `correlationId`: The optional correlation ID from `TraceContext` (included only when non-empty)
+    * `correlation_id`: The optional correlation ID from `TraceContext` (included only when non-empty)
 
 Traces include error information and span status codes for failed operations.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-crypto-broker/crypto-broker-server
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/dgraph-io/ristretto/v2 v2.4.0

--- a/internal/otel/attr.go
+++ b/internal/otel/attr.go
@@ -13,5 +13,5 @@ var (
 	AttributeCryptoCsrSize              = attribute.Key("crypto.csr_size")
 	AttributeCryptoCaCertSize           = attribute.Key("crypto.ca_cert_size")
 	AttributeCryptoCaKeySize            = attribute.Key("crypto.ca_key_size")
-	AttributeCorrelationId              = attribute.Key("correlationId")
+	AttributeCorrelationId              = attribute.Key("correlation_id")
 )


### PR DESCRIPTION
## Summary
- emit the OpenTelemetry correlation attribute as correlation_id
- update OTEL documentation to reference the SAP-supported field name

## Why
SAP Application Logging supports correlation_id. The protobuf field remains correlationId for wire/API compatibility, while emitted observability attributes now use the field name SAP can index.
