### PR TITLE
feat: Improve Dockerfile for multi-arch builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Version control & CI
+.git
+.gitignore
+.gitmodules
+.githooks/
+.github/
+
+# Local env & tooling caches
+.env
+.env.example
+.task/
+.golangci.yml
+Taskfile.yaml
+
+# Build outputs & benchmark artefacts (rebuilt inside the image)
+bin/
+benchmark-results.json
+
+# Docs & licensing (not needed to build the binary)
+*.md
+docs/
+LICENSE
+LICENSES/
+REUSE.toml
+
+# The Dockerfile itself lives in docker/
+docker/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,11 +5,17 @@ ARG ALPINE_VERSION=3.24
 ARG GRPC_HEALTH_PROBE_VERSION=v0.4.53
 
 ## Build
-FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
+# --platform=$BUILDPLATFORM builds on the builder's native architecture and
+# cross-compiles to the requested TARGETOS/TARGETARCH (both injected by buildx),
+# so a single Dockerfile can produce amd64 and arm64 images.
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
-# Install git for go install / module fetching
+## Install git for go install / module fetching
 RUN apk add --no-cache git
 
 COPY go.mod ./
@@ -19,23 +25,35 @@ RUN  go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 go build -o app ./cmd/server
+# -trimpath makes the build reproducible (no local paths baked in); -s -w drop
+# the symbol table and debug info to shrink the binary.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build -trimpath -ldflags="-s -w" -o app ./cmd/server
 
 ## Redeclare GRPC_HEALTH_PROBE_VERSION
 ARG GRPC_HEALTH_PROBE_VERSION
-## Install grpc-health-probe for health checks
-RUN CGO_ENABLED=0 go install github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_PROBE_VERSION}
+## Install grpc-health-probe for health checks (built for the target arch; the
+## `find` normalises the output path, which differs for cross-compiled installs).
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go install github.com/grpc-ecosystem/grpc-health-probe@${GRPC_HEALTH_PROBE_VERSION} \
+ && cp "$(find /go/bin -name grpc-health-probe -type f | head -n1)" /grpc-health-probe
 
 ## Deploy with scratch docker image (no other binaries, dependencies, etc)
 FROM scratch
 
 WORKDIR /app
 
-# Copy server and profile
+## Copy server and profile
 COPY --from=build /app/app .
 COPY --from=build /app/example-profiles ./profiles
-# Healthcheck: use grpc-health-probe to check the gRPC health endpoint
-COPY --from=build /go/bin/grpc-health-probe /usr/local/bin/grpc-health-probe
+## Healthcheck: use grpc-health-probe to check the gRPC health endpoint
+COPY --from=build /grpc-health-probe /usr/local/bin/grpc-health-probe
+
+# Run as a non-root user. In Platform Mesh the operator injects this container as
+# the sidecar and overrides the uid to 1000 (the owner of the shared Unix socket),
+# so defaulting to 1000 here keeps standalone `docker run` consistent with the
+# in-cluster behaviour.
+USER 1000:1000
 
 ENTRYPOINT ["./app"]
 


### PR DESCRIPTION
## Description
Add a .dockerignore file s.t. not all files are copied to the Dockerfile during building (reduce build time).
Add multi-arch support in Dockerfile.
Run container as non-root user.

## Type of change
- [ ] Bug fix
- [x] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
