### PR TITLE
fix: Adjust file permission for Profiles.yaml file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,12 @@ RUN  go mod download
 
 COPY . .
 
+# Normalise the profile permissions so they are world-readable and the directory
+# is world-traversable. Git does not track the read bit, so a fresh clone can end
+# up with group-restricted files; this guarantees the non-root runtime user
+# (uid 1000, see USER below) can read them after they are copied into the image.
+RUN chmod -R a+rX example-profiles
+
 # -trimpath makes the build reproducible (no local paths baked in); -s -w drop
 # the symbol table and debug info to shrink the binary.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \


### PR DESCRIPTION
## Description
Make the Profiles.yaml file readable by the user 1000 which is running inside of the container.
Otherwise the Crypto-Broker-Server cannot read the Profiles.yaml file and will fail at startup.

## Type of change
- [x] Bug fix
- [ ] Addition of feature
- [ ] Breaking change (Bug or New feature that would cause existing functionality/consumers to not work as expected. Reviewers might change this.)
- [ ] None of the above (Reviewers might ask for more clarification.)

## Checklist:
- [x] Supplied as many details as possible on this change
- [x] The code is easy to read and maintainable by others
- [ ] Corresponding changes to the documentation has been done
- [ ] Already existing and new unit tests were added and pass locally
